### PR TITLE
fix(extension): 断开 GObject 循环引用以防止注销时整机卡死

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -23,11 +23,16 @@ const MouseTrailLayer = GObject.registerClass(
   },
   class MouseTrailLayer extends St.DrawingArea {
     _init(extension) {
-      this._extension = extension;
       super._init({ reactive: false });
+      this._extension = extension;
       this.set_track_hover(false);
       this.set_reactive(false);
       this.set_size(global.stage.width, global.stage.height);
+      // 在 destroy 信号中断开对 extension 的回引用，打破 GObject<->JS 循环引用。
+      // 这是注销时整机卡死的根因：GC 终结阶段回调进已释放对象会触发 native abort。
+      this.connect("destroy", () => {
+        this._extension = null;
+      });
     }
 
     vfunc_parent_set() {
@@ -46,9 +51,11 @@ const MouseTrailLayer = GObject.registerClass(
     vfunc_pick(_pickContext) {}
 
     vfunc_repaint() {
+      const extension = this._extension;
+      if (!extension) return;
       const cr = this.get_context();
       try {
-        this._extension._onRepaint(cr);
+        extension._onRepaint(cr);
       } catch (_) {}
       cr.$dispose();
     }
@@ -219,6 +226,8 @@ export default class MouseTrailExtension extends Extension {
     }
 
     if (this._drawingLayer) {
+      // 先断开回引用，确保后续 destroy 触发的 vfunc 回调不会再进入 JS
+      this._drawingLayer._extension = null;
       try {
         this._cont?.remove_child(this._drawingLayer);
         global.stage.remove_child(this._cont);


### PR DESCRIPTION
在 MouseTrailLayer 初始化时先调用 super._init() 再赋值 _extension，并连接 destroy 信号在销毁时将 _extension 置 null；在 vfunc_repaint 中先检查 _extension 是否有效；在清理过程中主动断开 _drawingLayer._extension 引用。这些改动避免了 JS 与 GObject 之间的循环引用，消除 GC 终结阶段因回调已释放对象而触发的 native abort。